### PR TITLE
Fix PATH lacking homebrew binary

### DIFF
--- a/iterm2-zmodem.sh
+++ b/iterm2-zmodem.sh
@@ -12,7 +12,7 @@
 # https://www.satimage.fr/software/en/smile/external_codes/file_paths.html
 # https://blog.sapegin.me/all/show-gui-dialog-from-shell/
 
-export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 SEND_DIALOG_TITLE="Send File - Zmodem"
 RECEIVE_DIALOG_TITLE="Receive File - Zmodem"


### PR DESCRIPTION
iterm2 pop up an error "Command not found: sz" due to homebrew bin is not in the PATH. This commit could fix it